### PR TITLE
Improvement: Integrate Multi-Tile Listening #4

### DIFF
--- a/components/Day.js
+++ b/components/Day.js
@@ -9,7 +9,6 @@ export default function Day({
   textStyle = {},
   textProps = {},
 }) {
-  console.log(text);
   return (
     <View style={[styles.container, containerStyle]}>
       <View style={wrapperStyle}>

--- a/components/Message.js
+++ b/components/Message.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { StyleSheet, View, Text } from "react-native";
+import { StyleSheet, View, Text, Platform, Image } from "react-native";
 import Day from "./Day";
 import dayjs from "dayjs";
 import { SvgUri } from "react-native-svg";
@@ -41,10 +41,17 @@ const Message = ({ currentMessage, previousMessage = {}, ...props }) => {
       <View style={styles.messageAvatarAndContentWrapper}>
         {showAvatar ? (
           <View style={styles.avatarWrapper}>
-            <SvgUri
-              uri={currentMessage.user.avatar}
-              style={styles.messageAvatar}
-            />
+            {Platform.OS === "web" ? (
+              <Image
+                source={{ uri: currentMessage.user.avatar }}
+                style={styles.messageAvatar}
+              />
+            ) : (
+              <SvgUri
+                uri={currentMessage.user.avatar}
+                style={styles.messageAvatar}
+              />
+            )}
           </View>
         ) : (
           <View style={styles.avatarWrapperEmpty} />

--- a/components/Message.js
+++ b/components/Message.js
@@ -32,13 +32,12 @@ const Message = ({ currentMessage, previousMessage = {}, ...props }) => {
       {showDay && (
         <Day text={new Date(currentMessage.createdAt).toLocaleDateString()} />
       )}
-      {showAvatar && (
-        <View style={styles.userAndTimeWrapper}>
-          <Text style={styles.messageUserText}>{currentMessage.user.name}</Text>
-          <Text style={styles.timestamp}>{timestamp}</Text>
-        </View>
-      )}
-      <View style={styles.messageAvatarAndContentWrapper}>
+      <View
+        style={[
+          styles.messageAvatarAndContentWrapper,
+          showAvatar ? { marginTop: 5 } : {},
+        ]}
+      >
         {showAvatar ? (
           <View style={styles.avatarWrapper}>
             {Platform.OS === "web" ? (
@@ -56,8 +55,17 @@ const Message = ({ currentMessage, previousMessage = {}, ...props }) => {
         ) : (
           <View style={styles.avatarWrapperEmpty} />
         )}
-
-        <Text style={styles.messageText}>{currentMessage.text}</Text>
+        <View>
+          {showAvatar && (
+            <View style={styles.userAndTimeWrapper}>
+              <Text style={styles.messageUserText}>
+                {currentMessage.user.name}
+              </Text>
+              <Text style={styles.timestamp}>{timestamp}</Text>
+            </View>
+          )}
+          <Text style={styles.messageText}>{currentMessage.text}</Text>
+        </View>
       </View>
     </View>
   );
@@ -80,23 +88,16 @@ const styles = StyleSheet.create({
   },
   userAndTimeWrapper: {
     flexDirection: "row",
-    alignItems: "flex-end",
+    alignItems: "center",
     marginVertical: 5,
   },
-  // me: {
-  //   backgroundColor: "#2f3242",
-  // },
-  // otherUser: {
-  //   backgroundColor: "#3a3e52",
-  // },
   messageWrapper: {
     marginHorizontal: 15,
-    // marginTop: 5,
-    // marginBottom: 10,
   },
   messageUserText: {
     color: "#000000",
     fontSize: 18,
+    fontWeight: "bold",
   },
   avatarWrapper: {
     height: 40,
@@ -117,13 +118,14 @@ const styles = StyleSheet.create({
   messageText: {
     color: "#000000",
     paddingVertical: 0,
-    paddingHorizontal: 15,
+    paddingRight: 15,
 
     fontSize: 15,
   },
   timestamp: {
     color: "#000000b7",
-    fontSize: 12,
+    fontWeight: "300",
+    fontSize: 14,
     marginLeft: 10,
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -5085,6 +5085,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.throttle": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "expo-status-bar": "~1.0.2",
     "firebase": "^8.0.0",
     "install": "^0.13.0",
+    "lodash.flatten": "^4.4.0",
     "npm": "^6.14.8",
     "prop-types": "^15.7.2",
     "react": "16.13.1",

--- a/screens/Auth.js
+++ b/screens/Auth.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useGlobal } from "reactn";
-import { Platform, TouchableOpacity, Text, View } from "react-native";
+import { Text, View } from "react-native";
 import firebase from "firebase/app";
 import "firebase/auth";
 import randomName from "../utils/getRandomName";
@@ -31,12 +31,13 @@ export default function Auth() {
     firebase.auth().onAuthStateChanged(function (user) {
       if (user) {
         // User is signed in.
-        var uid = user.uid;
+        const uid = user.uid;
+        const name = randomName();
 
         setUser({
           id: uid,
-          name: randomName(),
-          avatar: `https://avatars.dicebear.com/api/gridy/${user.uid}.svg`,
+          name,
+          avatar: `https://avatars.dicebear.com/api/gridy/${name}.svg`,
         });
       } else {
         // User is signed out.

--- a/utils/common.js
+++ b/utils/common.js
@@ -1,0 +1,1 @@
+// commonly used utility functions go here


### PR DESCRIPTION
Closes #4 

This was actually an interesting and slightly more complicated issue to solve. 

Since Firestore's snapshot.forEach pattern only lets you `.data()` items one document/collection at a time, and the best you can do is aggregate them all into one array one snapshot at a time, running setMessages every time there was an update wouldn't work.

The solution (documented in-file) was to create an object of arrays, with the key being the geo-tile ID and the value being the aggregated snapshot for that geo-tile's messages like so:

```
{
39.93+-76.61 : [
    {...}
  ],
39.93+-76.62 : [
    {...}
  ],
  ...
}
```

This way I could update just the messages that came from one geo-tile and not lose the others (if any) since each snapshot would resolve at a different time, basically just patching a dictionary of the messages we could then compress into a single, sorted array of messages, which happens in a useEffect hook.
